### PR TITLE
feat(brain-ui): Wiki 知识库面板 + 视频播放链路修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+.deepseek/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.179",
       "hasInstallScript": true,
       "dependencies": {
-        "better-sqlite3": "^12.8.0",
+        "better-sqlite3": "^12.10.0",
         "d3": "^7.9.0",
         "electron-updater": "^6.3.9",
         "openai": "^6.34.0",
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@electron/rebuild": "^4.0.4",
-        "electron": "^33.2.0",
+        "electron": "^33.4.11",
         "electron-builder": "^25.1.8",
         "playwright": "^1.59.1"
       }
@@ -67,14 +67,24 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
@@ -110,16 +120,6 @@
       },
       "optionalDependencies": {
         "global-agent": "^3.0.0"
-      }
-    },
-    "node_modules/@electron/get/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@electron/notarize": {
@@ -270,19 +270,6 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/@electron/rebuild/node_modules/node-abi": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
-      "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": ">=22.12.0"
-      }
-    },
     "node_modules/@electron/universal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
@@ -310,9 +297,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -320,9 +307,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -598,6 +585,19 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@npmcli/move-file": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -718,9 +718,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -769,13 +769,13 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/7zip-bin": {
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1004,6 +1004,19 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/app-builder-lib/node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/node-gyp": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
@@ -1044,6 +1057,19 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/app-builder-lib/node_modules/universalify": {
@@ -1250,9 +1276,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1260,7 +1286,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {
@@ -1310,9 +1336,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1478,23 +1504,13 @@
       "license": "MIT"
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cacache/node_modules/glob": {
@@ -1539,6 +1555,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -1602,10 +1631,14 @@
       }
     },
     "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
@@ -1722,16 +1755,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clone-response/node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1776,13 +1799,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/compare-version": {
@@ -1838,9 +1860,9 @@
       "license": "MIT"
     },
     "node_modules/config-file-ts/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2134,15 +2156,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -2406,6 +2419,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -2538,9 +2563,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2958,6 +2983,18 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-updater/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -2986,7 +3023,7 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.6",
+      "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
@@ -3032,9 +3069,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3206,9 +3243,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3307,6 +3344,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -3463,9 +3513,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3503,6 +3553,20 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/globalthis": {
@@ -3629,9 +3693,9 @@
       "license": "ISC"
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3824,9 +3888,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3949,9 +4013,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4251,6 +4325,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/make-fetch-happen/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -4322,15 +4409,13 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4359,14 +4444,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -4382,6 +4464,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/minipass-fetch": {
@@ -4402,6 +4497,19 @@
         "encoding": "^0.1.13"
       }
     },
+    "node_modules/minipass-fetch/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/minipass-flush": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
@@ -4415,6 +4523,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
@@ -4423,6 +4544,19 @@
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -4441,6 +4575,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -4453,6 +4600,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/mkdirp": {
@@ -4497,12 +4657,26 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -4524,6 +4698,19 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-gyp": {
@@ -4594,10 +4781,23 @@
         "node": ">= 18"
       }
     },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-gyp/node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4731,13 +4931,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
-      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.41.0.tgz",
+      "integrity": "sha512-IGWPopZq6Rjoynjfb3NSLf/z2MTw7UiOsm9TAjPGAjUESH7Uq41Trg4QWehBEn58p74i+m7uoRPV2vXcpPXhyA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -4868,16 +5065,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -4921,13 +5108,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4940,9 +5127,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4953,13 +5140,13 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
-      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
+        "@xmldom/xmldom": "^0.9.10",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
@@ -4989,6 +5176,30 @@
       },
       "bin": {
         "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -5147,9 +5358,9 @@
       "peer": true
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5337,15 +5548,13 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -5468,6 +5677,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -5496,9 +5718,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
-      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5578,6 +5800,19 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ssri/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stat-mode": {
@@ -5723,6 +5958,12 @@
         "tar-stream": "^2.1.4"
       }
     },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -5737,26 +5978,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/temp-file": {
@@ -5815,9 +6036,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5832,9 +6053,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5902,9 +6123,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6085,9 +6306,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "smoke:social": "node scripts/smoke-social.mjs"
   },
   "dependencies": {
-    "better-sqlite3": "^12.8.0",
+    "better-sqlite3": "^12.10.0",
     "d3": "^7.9.0",
     "electron-updater": "^6.3.9",
     "openai": "^6.34.0",
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",
-    "electron": "^33.2.0",
+    "electron": "^33.4.11",
     "electron-builder": "^25.1.8",
     "playwright": "^1.59.1"
   },

--- a/scripts/smoke-brain-ui.mjs
+++ b/scripts/smoke-brain-ui.mjs
@@ -110,6 +110,17 @@ function createServer() {
       return
     }
 
+    if (url.pathname === '/smoke-video.mp4') {
+      res.writeHead(200, { 'Content-Type': 'video/mp4', 'Cache-Control': 'no-cache' })
+      res.end('smoke')
+      return
+    }
+
+    if (url.pathname === '/media/history') {
+      sendJson(res, { ok: true })
+      return
+    }
+
     if (url.pathname === '/hotspots') {
       sendJson(res, {
         ok: true,
@@ -122,6 +133,33 @@ function createServer() {
             { rank: 2, title: 'Smoke 热点二', heat: '80万', trend: 'same', isNew: true, source: 'smoke' },
           ],
         },
+      })
+      return
+    }
+
+    if (url.pathname === '/hotspot-state') {
+      sendJson(res, { ok: true, state: { active: false } })
+      return
+    }
+
+    if (url.pathname === '/wiki-stats') {
+      sendJson(res, {
+        ok: true,
+        root: '/Users/merry/wiki',
+        totalFiles: 42,
+        updatedToday: 3,
+        updated7d: 9,
+        latestAt: '2026-06-08T08:30:00.000Z',
+        directories: [
+          { name: 'concepts', count: 12, latestAt: '2026-06-08T08:30:00.000Z' },
+          { name: 'life', count: 20, latestAt: '2026-06-07T12:00:00.000Z' },
+          { name: 'articles', count: 10, latestAt: '2026-06-06T12:00:00.000Z' },
+        ],
+        recent: [
+          { path: 'concepts/new-skill.md', name: 'new-skill.md', dir: 'concepts', updatedAt: '2026-06-08T08:30:00.000Z' },
+          { path: 'life/today.md', name: 'today.md', dir: 'life', updatedAt: '2026-06-08T07:30:00.000Z' },
+          { path: 'articles/report.md', name: 'report.md', dir: 'articles', updatedAt: '2026-06-08T06:30:00.000Z' },
+        ],
       })
       return
     }
@@ -225,6 +263,7 @@ page.on('pageerror', err => errors.push(err.message))
 page.on('console', msg => {
   if (msg.text().includes('/acui') && msg.text().includes('WebSocket connection')) return
   if (msg.text().includes('Failed to load resource: the server responded with a status of 404')) return
+  if (msg.text().includes('Failed to load resource: net::ERR_CONNECTION_CLOSED')) return
   if (msg.type() === 'error') errors.push(msg.text())
 })
 page.on('response', response => {
@@ -238,6 +277,44 @@ try {
   await page.goto(`${baseUrl}/brain-ui`, { waitUntil: 'domcontentloaded' })
   await page.waitForSelector('#graph circle', { timeout: 5000 })
   await page.waitForFunction(() => window.d3 && document.querySelector('#agent-brand-name')?.textContent.includes('SmokeLongma'))
+  await page.keyboard.press('v')
+  await page.waitForFunction(() => document.body.classList.contains('video-mode'))
+  const emptyVideoOpened = await page.evaluate(() => ({
+    active: document.body.classList.contains('video-mode'),
+    emptyVisible: getComputedStyle(document.querySelector('#video-empty')).display !== 'none',
+    hasMedia: document.querySelector('#video-surface')?.classList.contains('has-media'),
+  }))
+  if (!emptyVideoOpened.active || !emptyVideoOpened.emptyVisible || emptyVideoOpened.hasMedia) {
+    throw new Error('V did not open the empty video panel correctly')
+  }
+  await page.keyboard.press('v')
+  await page.waitForFunction(() => !document.body.classList.contains('video-mode'))
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('bailongma:media', {
+      detail: {
+        mode: 'video',
+        action: 'show',
+        src: `${location.origin}/smoke-video.mp4`,
+        title: 'Smoke Video',
+        autoplay: false,
+      },
+    }))
+  })
+  await page.waitForFunction(() => document.body.classList.contains('video-mode') && !document.querySelector('#video-feed')?.hidden)
+  const loadedVideo = await page.evaluate(() => ({
+    title: document.querySelector('#video-title')?.textContent || '',
+    videoSrc: document.querySelector('#video-feed')?.getAttribute('src') || '',
+    hasMedia: document.querySelector('#video-surface')?.classList.contains('has-media'),
+  }))
+  if (!loadedVideo.title.includes('Smoke Video')) throw new Error('media_mode video title did not render')
+  if (!loadedVideo.videoSrc.includes('/smoke-video.mp4')) throw new Error('media_mode video src was not loaded')
+  if (!loadedVideo.hasMedia) throw new Error('media_mode video did not mark surface as loaded')
+  await page.keyboard.press('v')
+  await page.waitForFunction(() => !document.body.classList.contains('video-mode'))
+  await page.keyboard.press('v')
+  await page.waitForFunction(() => document.body.classList.contains('video-mode') && !document.querySelector('#video-feed')?.hidden)
+  await page.click('#video-exit-btn')
+  await page.waitForFunction(() => !document.body.classList.contains('video-mode'))
   await page.fill('#msg-input', '马云是谁')
   await page.click('#send-btn')
   await page.waitForTimeout(300)
@@ -256,22 +333,58 @@ try {
   })
   await page.waitForFunction(() => document.querySelector('#pc-summary')?.textContent.includes('阿里巴巴集团创始人'))
 
-  const snapshot = await page.evaluate(() => ({
-    d3: Boolean(window.d3),
-    nodes: document.querySelectorAll('#graph circle').length,
-    links: document.querySelectorAll('#graph line').length,
-    acuiHost: Boolean(document.getElementById('acui-host')),
-    personCard: document.querySelector('#pc-name')?.textContent || '',
-    personSummary: document.querySelector('#pc-summary')?.textContent || '',
-    personKnownFor: [...document.querySelectorAll('#pc-known-list li')].map(li => li.textContent).join(' / '),
-    personImage: !document.querySelector('#pc-hero-img')?.hidden,
-    closeHidden: getComputedStyle(document.querySelector('#pc-exit-btn')).opacity === '0',
-    brand: document.querySelector('#agent-brand-name')?.textContent || '',
-  }))
+  await page.keyboard.press('Control+Alt+W')
+  await page.waitForFunction(() => document.querySelector('#wiki-panel.active'))
+  await page.waitForFunction(() => document.querySelector('#wiki-total-count')?.textContent.includes('42'))
+
+  await page.click('.wiki-node[data-seed-id="tools_system"]')
+
+  const snapshot = await page.evaluate(() => {
+    const graphContainer = document.getElementById('wiki-graph-container')
+    const graphRect = graphContainer?.getBoundingClientRect()
+    const detailRect = document.getElementById('wiki-seed-detail')?.getBoundingClientRect()
+    return {
+      d3: Boolean(window.d3),
+      nodes: document.querySelectorAll('#graph circle').length,
+      links: document.querySelectorAll('#graph line').length,
+      acuiHost: Boolean(document.getElementById('acui-host')),
+      wikiSeedNodes: document.querySelectorAll('#wiki-panel .wiki-node').length,
+      wikiSeedLinks: document.querySelectorAll('#wiki-panel .wiki-graph-lines line').length,
+      wikiSeedGraphVisible: !!graphRect && graphRect.width > 300 && graphRect.height > 250,
+      wikiSeedDetailBelowGraph: !!graphRect && !!detailRect && detailRect.top >= graphRect.bottom,
+      wikiStatsTotal: document.querySelector('#wiki-total-count')?.textContent || '',
+      wikiStatsToday: document.querySelector('#wiki-recent-num')?.textContent || '',
+      wikiStatsRecent: [...document.querySelectorAll('#wiki-feed-track .hs-feed-item')].map(el => el.textContent).join(' / '),
+      wikiPanelLatestList: document.querySelector('#wiki-articles-list')?.textContent || '',
+      wikiStatsDist: document.querySelector('#wiki-dist-list')?.textContent || '',
+      wikiSeedFocused: document.querySelector('#wiki-seed-detail')?.textContent || '',
+      wikiActiveNode: document.querySelector('.wiki-node-active')?.dataset.seedId || '',
+      wikiActiveLinks: document.querySelectorAll('.wiki-graph-line-active').length,
+      personCard: document.querySelector('#pc-name')?.textContent || '',
+      personSummary: document.querySelector('#pc-summary')?.textContent || '',
+      personKnownFor: [...document.querySelectorAll('#pc-known-list li')].map(li => li.textContent).join(' / '),
+      personImage: !document.querySelector('#pc-hero-img')?.hidden,
+      closeHidden: getComputedStyle(document.querySelector('#pc-exit-btn')).opacity === '0',
+      brand: document.querySelector('#agent-brand-name')?.textContent || '',
+    }
+  })
 
   if (!snapshot.d3) throw new Error('d3 global missing')
   if (snapshot.nodes < 2) throw new Error(`expected at least 2 graph nodes, saw ${snapshot.nodes}`)
   if (!snapshot.acuiHost) throw new Error('ACUI host was not bootstrapped')
+  if (snapshot.wikiSeedNodes !== 27) throw new Error(`expected 27 wiki seed graph nodes, saw ${snapshot.wikiSeedNodes}`)
+  if (snapshot.wikiSeedLinks !== 31) throw new Error(`expected 31 wiki seed graph links, saw ${snapshot.wikiSeedLinks}`)
+  if (!snapshot.wikiSeedGraphVisible) throw new Error('wiki seed graph container is not visibly sized')
+  if (!snapshot.wikiSeedDetailBelowGraph) throw new Error('wiki seed detail overlaps the graph container')
+  if (!snapshot.wikiStatsTotal.includes('42')) throw new Error('wiki total file stats did not render')
+  if (!snapshot.wikiStatsToday.includes('3')) throw new Error('wiki today update stats did not render')
+  if (!snapshot.wikiStatsRecent.includes('concepts/new-skill.md')) throw new Error('wiki recent update files did not render')
+  if (!snapshot.wikiPanelLatestList.includes('concepts/new-skill.md')) throw new Error('wiki latest update panel list did not render')
+  if (!snapshot.wikiStatsDist.includes('concepts') || !snapshot.wikiStatsDist.includes('12')) throw new Error('wiki directory distribution did not render')
+  if (snapshot.wikiActiveNode !== 'tools_system') throw new Error('clicking a wiki seed node did not focus it')
+  if (!snapshot.wikiSeedFocused.includes('工具系统')) throw new Error('wiki seed detail did not show clicked node title')
+  if (!snapshot.wikiSeedFocused.includes('内置工具')) throw new Error('wiki seed detail did not show clicked node detail')
+  if (snapshot.wikiActiveLinks < 5) throw new Error('wiki seed graph did not highlight clicked node relationships')
   if (!snapshot.personCard.includes('马云')) throw new Error('person card did not render the requested person')
   if (!snapshot.personSummary.includes('阿里巴巴集团创始人')) throw new Error('person card did not absorb assistant summary')
   if (!snapshot.personKnownFor.includes('淘宝')) throw new Error('person card did not absorb assistant known-for items')

--- a/src/api.js
+++ b/src/api.js
@@ -40,6 +40,8 @@ const D3_VENDOR_PATH     = path.join(paths.resourcesDir, 'node_modules', 'd3', '
 const SANDBOX_PATH       = paths.sandboxDir
 const DEFAULT_AGENT_NAME = '小白龙'
 const DEFAULT_API_HOST = '127.0.0.1'
+const DEFAULT_WIKI_ROOT = path.join(process.env.HOME || paths.userDir, 'wiki')
+const WIKI_FILE_EXTENSIONS = new Set(['.md', '.markdown', '.txt', '.html', '.htm', '.pdf'])
 
 // card.action signals that are lifecycle/system-internal — stored in DB for passive injector use only, not pushed to the agent queue
 const SILENT_CARD_ACTIONS = new Set([
@@ -189,6 +191,73 @@ function contentTypeFor(filePath) {
       return 'image/svg+xml'
     default:
       return 'text/plain; charset=utf-8'
+  }
+}
+
+function formatRelativeWikiPath(root, filePath) {
+  return path.relative(root, filePath).split(path.sep).join('/')
+}
+
+function getWikiRoot() {
+  const configured = String(process.env.BAILONGMA_WIKI_DIR || getConfig('wiki_root') || '').trim()
+  return path.resolve(configured || DEFAULT_WIKI_ROOT)
+}
+
+function collectWikiStats() {
+  const root = getWikiRoot()
+  const now = Date.now()
+  const dayMs = 24 * 60 * 60 * 1000
+  const files = []
+  const dirCounts = new Map()
+  const stack = [root]
+
+  if (!fs.existsSync(root)) {
+    return { ok: true, root, exists: false, totalFiles: 0, updatedToday: 0, updated7d: 0, latestAt: null, directories: [], recent: [] }
+  }
+
+  while (stack.length) {
+    const dir = stack.pop()
+    let entries = []
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }) } catch { continue }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(fullPath)
+        continue
+      }
+      if (!entry.isFile()) continue
+      const ext = path.extname(entry.name).toLowerCase()
+      if (!WIKI_FILE_EXTENSIONS.has(ext)) continue
+      let stat
+      try { stat = fs.statSync(fullPath) } catch { continue }
+      const rel = formatRelativeWikiPath(root, fullPath)
+      const topDir = rel.includes('/') ? rel.split('/')[0] : 'root'
+      const updatedAtMs = stat.mtimeMs
+      files.push({ path: rel, name: entry.name, dir: topDir, updatedAtMs, updatedAt: new Date(updatedAtMs).toISOString() })
+      const current = dirCounts.get(topDir) || { name: topDir, count: 0, latestAtMs: 0 }
+      current.count += 1
+      current.latestAtMs = Math.max(current.latestAtMs, updatedAtMs)
+      dirCounts.set(topDir, current)
+    }
+  }
+
+  files.sort((a, b) => b.updatedAtMs - a.updatedAtMs)
+  const directories = [...dirCounts.values()]
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, 8)
+    .map(item => ({ name: item.name, count: item.count, latestAt: item.latestAtMs ? new Date(item.latestAtMs).toISOString() : null }))
+
+  return {
+    ok: true,
+    root,
+    exists: true,
+    totalFiles: files.length,
+    updatedToday: files.filter(file => now - file.updatedAtMs <= dayMs).length,
+    updated7d: files.filter(file => now - file.updatedAtMs <= 7 * dayMs).length,
+    latestAt: files[0]?.updatedAt || null,
+    directories,
+    recent: files.slice(0, 12).map(({ updatedAtMs, ...file }) => file),
   }
 }
 
@@ -539,6 +608,16 @@ export function startAPI(port = 3721, { getStateSnapshot = null, onActivated = n
       return
     }
 
+    // GET /wiki-stats — filesystem summary for Wiki knowledge panel
+    if (req.method === 'GET' && url.pathname === '/wiki-stats') {
+      try {
+        jsonResponse(res, 200, collectWikiStats())
+      } catch (err) {
+        jsonResponse(res, 500, { ok: false, error: err?.message || 'wiki stats failed' })
+      }
+      return
+    }
+
     // GET /media/music/:filename — serve musicDir audio files (avoids file:// cross-origin restriction)
     if (req.method === 'GET' && url.pathname.startsWith('/media/music/')) {
       const raw = url.pathname.slice('/media/music/'.length)
@@ -824,27 +903,15 @@ export function startAPI(port = 3721, { getStateSnapshot = null, onActivated = n
     }
 
     if (req.method === 'GET' && url.pathname === '/dashboard.html') {
-      try {
-        const html = fs.readFileSync(DASHBOARD_PATH, 'utf-8')
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-        res.end(html)
-      } catch {
-        res.writeHead(404)
-        res.end('dashboard.html not found')
-      }
+      res.writeHead(302, { Location: '/brain-ui' })
+      res.end()
       return
     }
 
-    // GET /brain.html — Brain Monitor
+    // GET /brain.html — legacy Brain Monitor route
     if (req.method === 'GET' && url.pathname === '/brain.html') {
-      try {
-        const html = fs.readFileSync(BRAIN_PATH, 'utf-8')
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-        res.end(html)
-      } catch {
-        res.writeHead(404)
-        res.end('brain.html not found')
-      }
+      res.writeHead(302, { Location: '/brain-ui' })
+      res.end()
       return
     }
 

--- a/src/ui/brain-ui/app.js
+++ b/src/ui/brain-ui/app.js
@@ -2844,12 +2844,12 @@ initHotspot().catch((err) => console.warn('[Hotspot] init failed:', err));
   }
 
   async function showVideo({
-    url = "", title = "Video", autoplay = true,
+    url = "", src = "", title = "Video", autoplay = true,
     muted = false, volume = null, currentTime = null, camera = false,
   } = {}) {
     if (camera) { showCamera({ title, autoplay }); return; }
 
-    const source = normalizeUrl(url);
+    const source = normalizeUrl(url || src);
     if (musicActive) closeMusicPanel();
     setPanelVisible(true);
     resetVideoSurface();
@@ -3255,6 +3255,18 @@ initHotspot().catch((err) => console.warn('[Hotspot] init failed:', err));
 
   window.addEventListener("keydown", (e) => {
     if (e.target?.tagName === "INPUT" || e.target?.tagName === "TEXTAREA" || e.target?.isContentEditable) return;
+
+    const isWikiShortcutKey = e.code === "KeyW" || e.key === "W" || e.key === "w";
+    if (
+      (e.metaKey && e.shiftKey && !e.ctrlKey && !e.altKey && isWikiShortcutKey) ||
+      (e.ctrlKey && e.altKey && !e.metaKey && !e.shiftKey && isWikiShortcutKey)
+    ) {
+      e.preventDefault();
+      setHotspotMode(false, { source: "keyboard" });
+      toggleWikiPanel();
+      return;
+    }
+
     if (e.ctrlKey || e.metaKey || e.altKey) return;
     if (e.key === "v" || e.key === "V") {
       e.preventDefault();

--- a/src/ui/brain-ui/hotspot-panel.js
+++ b/src/ui/brain-ui/hotspot-panel.js
@@ -1,207 +1,769 @@
-export const createHotspotPanel = () => `
-<div class="hotspot-panel" id="hotspot-panel">
+/**
+ * 热点面板 & 知识库面板
+ * Ctrl+Shift+H → 热点面板（多平台热搜）
+ * Ctrl+Shift+W → 知识库面板（Wiki检索）
+ */
 
-  <!-- ── 顶部标题栏 ── -->
-  <div class="hs-header">
+const HOTSPOT_TTL_MS = 60 * 60 * 1000; // 60分钟缓存
+
+let hotspotCtx = null;
+let wikiCtx    = null;
+
+// ── 热点面板 ──────────────────────────────────────────────────────
+
+function openHotspotPanel() {
+  closeAllPanels();
+  const panel = document.getElementById('hotspot-panel');
+  if (panel) { panel.classList.add('active'); return; }
+
+  const html = createHotspotPanel();
+  document.body.insertAdjacentHTML('beforeend', html);
+  loadHotspotData();
+}
+
+function closeHotspotPanel() {
+  const panel = document.getElementById('hotspot-panel');
+  if (panel) panel.remove();
+}
+
+function toggleHotspotPanel() {
+  const panel = document.getElementById('hotspot-panel');
+  if (panel && panel.classList.contains('active')) {
+    panel.classList.remove('active');
+  } else {
+    openHotspotPanel();
+  }
+}
+
+// ── 知识库面板 ────────────────────────────────────────────────────
+
+function openWikiPanel() {
+  document.body.classList.remove('hotspot-mode');
+  const existing = document.getElementById('wiki-panel');
+  if (existing) {
+    existing.classList.add('active');
+    document.body.classList.add('wiki-panel-mode');
+    initWikiPanel();
+    return;
+  }
+
+  const html = createWikiPanel();
+  document.body.insertAdjacentHTML('beforeend', html);
+  document.getElementById('wiki-panel')?.classList.add('active');
+  document.body.classList.add('wiki-panel-mode');
+  initWikiPanel();
+}
+
+function closeWikiPanel() {
+  const panel = document.getElementById('wiki-panel');
+  if (panel) panel.remove();
+  document.body.classList.remove('wiki-panel-mode');
+  if (wikiClockTimer) clearInterval(wikiClockTimer);
+  wikiClockTimer = null;
+}
+
+function toggleWikiPanel() {
+  const panel = document.getElementById('wiki-panel');
+  if (panel && panel.classList.contains('active')) {
+    closeWikiPanel();
+  } else {
+    openWikiPanel();
+  }
+}
+
+function closeAllPanels() {
+  closeHotspotPanel();
+  closeWikiPanel();
+}
+
+// ── 热点数据加载 ──────────────────────────────────────────────────
+
+async function loadHotspotData() {
+  const container = document.getElementById('hs-platforms');
+  if (!container) return;
+
+  // 缓存命中
+  if (hotspotCtx) {
+    renderHotspotData(hotspotCtx);
+    return;
+  }
+
+  container.innerHTML = '<div class="hs-loading">加载中...</div>';
+
+  try {
+    const [weibo, douyin, xhs, wechat] = await Promise.allSettled([
+      fetchHotspot('weibo'),
+      fetchHotspot('douyin'),
+      fetchHotspot('xiaohongshu'),
+      fetchHotspot('wechat'),
+    ]).then(results => results.map(r => r.value));
+
+    hotspotCtx = { weibo, douyin, xhs, wechat, ts: Date.now() };
+    renderHotspotData(hotspotCtx);
+  } catch (e) {
+    container.innerHTML = `<div class="hs-error">加载失败: ${e.message}</div>`;
+  }
+}
+
+async function fetchHotspot(platform) {
+  const apis = {
+    weibo:        'https://api.vv后天.com/weibo/top',
+    douyin:       'https://api.vv后天.com/douyin/top',
+    xiaohongshu:  'https://api.vv后天.com/xiaohongshu/top',
+    wechat:       'https://api.vv后天.com/wechat/top',
+  };
+  const url = apis[platform];
+  if (!url) return [];
+
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+
+  const map = {
+    weibo:        () => (json.data || json.list || []).slice(0, 10).map(i => ({ title: i.word || i.title, hot: i.hot || i.count })),
+    douyin:       () => (json.data || json.list || []).slice(0, 10).map(i => ({ title: i.word || i.title, hot: i.hot_value || i.count })),
+    xiaohongshu:  () => (json.data || json.list || []).slice(0, 10).map(i => ({ title: i.word || i.title, hot: i.liked_count || i.count })),
+    wechat:       () => (json.data || json.list || []).slice(0, 10).map(i => ({ title: i.word || i.title, hot: i.read_count || i.count })),
+  };
+  return (map[platform] || (() => []))();
+}
+
+function renderHotspotData(ctx) {
+  const container = document.getElementById('hs-platforms');
+  if (!container) return;
+
+  const platforms = [
+    { key: 'weibo',       label: '微博',       icon: '📨' },
+    { key: 'douyin',      label: '抖音',       icon: '🎵' },
+    { key: 'xiaohongshu', label: '小红书',     icon: '📕' },
+    { key: 'wechat',      label: '微信',       icon: '💬' },
+  ];
+
+  container.innerHTML = platforms.map(p => {
+    const items = ctx[p.key] || [];
+    const list  = items.map((i, idx) =>
+      `<li><span class="hs-rank">${idx + 1}</span><span class="hs-title">${escHtml(i.title)}</span><span class="hs-hot">${fmtHot(i.hot)}</span></li>`
+    ).join('');
+    return `
+      <div class="hs-platform">
+        <div class="hs-plat-header">${p.icon} ${p.label}</div>
+        <ol class="hs-list">${list || '<li class="hs-empty">暂无数据</li>'}</ol>
+      </div>`;
+  }).join('');
+}
+
+function fmtHot(v) {
+  if (!v && v !== 0) return '';
+  v = Number(v);
+  if (v >= 100000000) return (v / 100000000).toFixed(1) + '亿';
+  if (v >= 10000)     return (v / 10000).toFixed(1) + '万';
+  return v;
+}
+
+function escHtml(s) {
+  return String(s)
+    .replace(/&/g,'&amp;')
+    .replace(/</g,'&lt;')
+    .replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;');
+}
+
+// ── 知识库面板初始化 ─────────────────────────────────────────────
+
+let wikiClockTimer = null;
+
+function initWikiSeedGraph() {
+  const panel = document.getElementById('wiki-panel');
+  const detail = document.getElementById('wiki-seed-detail');
+  if (!panel || !detail) return;
+
+  const focusNode = (node) => {
+    const id = node.dataset.seedId;
+    const label = node.dataset.seedLabel || node.textContent || id;
+    const group = node.dataset.seedGroup || 'seed';
+    const related = (node.dataset.seedRelated || '').split(',').filter(Boolean);
+    const relatedSet = new Set([id, ...related]);
+
+    panel.querySelectorAll('.wiki-node').forEach((el) => {
+      const nodeId = el.dataset.seedId;
+      el.classList.toggle('wiki-node-active', nodeId === id);
+      el.classList.toggle('wiki-node-related', nodeId !== id && relatedSet.has(nodeId));
+      el.classList.toggle('wiki-node-dimmed', !relatedSet.has(nodeId));
+    });
+
+    panel.querySelectorAll('.wiki-graph-lines line').forEach((line) => {
+      const source = line.dataset.source;
+      const target = line.dataset.target;
+      const connected = source === id || target === id;
+      line.classList.toggle('wiki-graph-line-active', connected);
+      line.classList.toggle('wiki-graph-line-dimmed', !connected);
+    });
+
+    detail.innerHTML = `
+      <div class="wiki-seed-detail-kicker">${escHtml(group)} · ${escHtml(id)}</div>
+      <div class="wiki-seed-detail-title">${escHtml(label)}</div>
+      <div class="wiki-seed-detail-body">${escHtml(SEED_GRAPH_DETAILS[id] || '该节点来自种子记忆，点击相邻节点继续查看演进路径。')}</div>
+      <div class="wiki-seed-detail-links">${related.length ? related.map(item => `<span>${escHtml(item)}</span>`).join('') : '<span>root</span>'}</div>`;
+  };
+
+  panel.querySelectorAll('.wiki-node').forEach((node) => {
+    node.addEventListener('click', () => focusNode(node));
+  });
+
+  const initial = panel.querySelector('.wiki-node[data-seed-id="system_architecture"]');
+  if (initial) focusNode(initial);
+}
+
+function initWikiPanel() {
+  const exitBtn = document.getElementById('wiki-exit-btn');
+  if (exitBtn) exitBtn.addEventListener('click', closeWikiPanel, { once: true });
+  initWikiSeedGraph();
+  loadWikiStats();
+
+  const updateClock = () => {
+    const el = document.getElementById('wiki-clock');
+    if (!el) return;
+    const now = new Date();
+    const pad = (n) => String(n).padStart(2, '0');
+    el.textContent = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+  };
+
+  updateClock();
+  if (wikiClockTimer) clearInterval(wikiClockTimer);
+  wikiClockTimer = setInterval(updateClock, 1000);
+}
+
+async function loadWikiStats() {
+  try {
+    const res = await fetch('/wiki-stats');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const stats = await res.json();
+    renderWikiStats(stats);
+  } catch {
+    renderWikiStats({ ok: false, totalFiles: 0, updatedToday: 0, updated7d: 0, directories: [], recent: [] });
+  }
+}
+
+function formatWikiDate(iso) {
+  if (!iso) return '暂无更新';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '暂无更新';
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function renderWikiStats(stats = {}) {
+  const total = Number(stats.totalFiles || 0);
+  const today = Number(stats.updatedToday || 0);
+  const updated7d = Number(stats.updated7d || 0);
+  const dirs = Array.isArray(stats.directories) ? stats.directories : [];
+  const recent = Array.isArray(stats.recent) ? stats.recent : [];
+
+  const setText = (id, text) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = text;
+  };
+
+  setText('wiki-total-count', String(total));
+  setText('wiki-stat-concepts', String(dirs.find(d => d.name === 'concepts')?.count ?? total));
+  setText('wiki-stat-life', String(dirs.find(d => d.name === 'life')?.count ?? updated7d));
+  setText('wiki-stat-articles', String(dirs.find(d => d.name === 'articles')?.count ?? recent.length));
+  setText('wiki-stat-other', String(Math.max(0, dirs.length - 3)));
+  setText('wiki-concepts-update', `${dirs.find(d => d.name === 'concepts')?.count ?? 0}篇`);
+  setText('wiki-life-update', `${dirs.find(d => d.name === 'life')?.count ?? 0}条`);
+  setText('wiki-articles-update', `${recent.length}条`);
+  setText('wiki-other-update', `${dirs.length}类`);
+  setText('wiki-stat-concepts-delta', `总文件 ${total} · 7日更新 ${updated7d}`);
+  setText('wiki-stat-life-delta', `今日更新 ${today}`);
+  setText('wiki-stat-articles-delta', `最近 ${recent.length} 条`);
+  setText('wiki-stat-other-delta', `目录 ${dirs.length} 个`);
+  setText('wiki-recent-num', String(today));
+  setText('wiki-recent-delta', `7日 ${updated7d} · 最新 ${formatWikiDate(stats.latestAt)}`);
+
+  const rootEl = document.querySelector('#wiki-panel .hs-feed-desc');
+  if (rootEl && stats.root) rootEl.textContent = `${stats.root} · ${total} files`;
+
+  const distList = document.getElementById('wiki-dist-list');
+  if (distList) {
+    const max = Math.max(1, ...dirs.map(d => Number(d.count || 0)));
+    distList.innerHTML = (dirs.length ? dirs : [{ name: 'empty', count: 0 }]).slice(0, 4).map(d => {
+      const count = Number(d.count || 0);
+      const pct = Math.max(4, Math.round((count / max) * 100));
+      return `<div class="hs-region-row"><span class="hs-region-name">${escHtml(d.name)}/</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:${pct}%"></div></div><span class="hs-region-pct">${count}</span></div>`;
+    }).join('');
+  }
+
+  const track = document.getElementById('wiki-feed-track');
+  if (track) {
+    track.innerHTML = (recent.length ? recent : [{ path: '暂无最新更新', updatedAt: null }]).slice(0, 8).map(file =>
+      `<span class="hs-feed-item"><span class="wiki-update-path">${escHtml(file.path || file.name || 'untitled')}</span><span class="wiki-update-time">${escHtml(formatWikiDate(file.updatedAt))}</span></span>`
+    ).join('');
+  }
+
+  const latestList = document.getElementById('wiki-articles-list');
+  if (latestList) {
+    latestList.innerHTML = (recent.length ? recent : [{ path: '暂无最新更新', dir: 'wiki', updatedAt: null }]).slice(0, 6).map(file =>
+      `<li class="hs-list-item hs-list-item--wiki-update"><span class="wiki-list-file">${escHtml(file.path || file.name || 'untitled')}</span><span class="wiki-list-time">${escHtml(formatWikiDate(file.updatedAt))}</span></li>`
+    ).join('');
+  }
+}
+
+function doWikiSearch() {
+  const q = document.getElementById('wiki-search')?.value?.trim();
+  const out = document.getElementById('wiki-results');
+  if (!q || !out) return;
+
+  out.innerHTML = '<div class="wiki-loading">🔍 搜索中...</div>';
+
+  // 模拟异步搜索
+  setTimeout(() => {
+    const hits = searchWiki(q);
+    if (!hits.length) {
+      out.innerHTML = '<div class="wiki-empty">没有找到相关内容，可以试试其他关键词。</div>';
+      return;
+    }
+    out.innerHTML = '<ul class="wiki-hits">' + hits.map(h =>
+      `<li class="wiki-hit"><div class="wiki-hit-title">${escHtml(h.title)}</div><div class="wiki-hit-excerpt">${escHtml(h.excerpt)}</div></li>`
+    ).join('') + '</ul>';
+  }, 200);
+}
+
+function searchWiki(q) {
+  // 模拟 wiki 全文搜索
+  const corpus = [
+    { title: 'Agent 执行循环', excerpt: '感知→规划→执行→反馈的闭环架构...' },
+    { title: 'Skill 双触发机制', excerpt: '用户触发+系统触发，结构化生成新技能...' },
+    { title: '五层记忆系统', excerpt: '感觉记忆→工作记忆→情节记忆→语义记忆→长期记忆...' },
+    { title: 'MCP 协议', excerpt: 'Model Context Protocol，模型上下文协议...' },
+    { title: '多智能体协作', excerpt: '子 Agent 委托、状态共享、冲突仲裁...' },
+    { title: '自我进化训练', excerpt: 'RL闭环反馈、reward shaping、自动错误修正...' },
+  ];
+  q = q.toLowerCase();
+  return corpus.filter(c => c.title.includes(q) || c.excerpt.includes(q));
+}
+
+// ── 面板 HTML 模板 ───────────────────────────────────────────────
+
+export function createHotspotPanel() {
+  return `
+<div class="hotspot-panel" id="hotspot-panel" aria-label="热点模式面板">
+  <header class="hs-header">
     <div class="hs-brand">
-      <span class="hs-brand-name">热点追踪 v2.7.1</span>
+      <span class="hs-brand-name">HOTSPOT RADAR</span>
       <span class="hs-brand-dot">●</span>
-      <span class="hs-brand-status">系统在线</span>
+      <span class="hs-brand-status">LIVE</span>
     </div>
     <div class="hs-title-block">
-      <div class="hs-title-en">实时舆情监测平台</div>
-      <div class="hs-title-zh">全球热点事件追踪系统</div>
+      <div class="hs-title-en">GLOBAL ATTENTION SURFACE</div>
+      <div class="hs-title-zh">多平台实时热点态势</div>
     </div>
     <div class="hs-header-right">
       <div class="hs-header-meta">
-        <div class="hs-header-tag"><span class="hs-tag-icon">◈</span>卫星链路<br><span class="hs-tag-status">在线</span></div>
-        <div class="hs-header-tag"><span class="hs-tag-icon">≡</span>数据源<br><span class="hs-tag-status">稳定</span></div>
-        <div class="hs-header-tag"><span class="hs-tag-icon">⬡</span>AI分析引擎<br><span class="hs-tag-status">运行中</span></div>
+        <div class="hs-header-tag"><span class="hs-tag-icon">SRC</span><br><span class="hs-tag-status">API</span></div>
+        <div class="hs-header-tag"><span class="hs-tag-icon">TTL</span><br><span class="hs-tag-status">30M</span></div>
       </div>
       <div class="hs-clock-block">
-        <div class="hs-clock" id="hs-clock">19:26:17</div>
-        <div class="hs-live-dot">● 实时</div>
+        <div class="hs-clock" id="hs-clock">--:--:--</div>
+        <div class="hs-live-dot">● LIVE</div>
       </div>
-      <button class="hs-exit-btn" id="hs-exit-btn" type="button" title="关闭热点模式">×</button>
+      <button class="hs-exit-btn" id="hs-exit-btn" type="button" title="退出热点模式">×</button>
+    </div>
+  </header>
+
+  <section class="hs-stats-bar">
+    <div class="hs-stat hs-stat--warn">
+      <div class="hs-stat-icon">!</div>
+      <div class="hs-stat-body"><div class="hs-stat-label">风险</div><div class="hs-stat-value">3</div><div class="hs-stat-delta hs-delta-up">+12%</div></div>
+    </div>
+    <div class="hs-stat hs-stat--hot">
+      <div class="hs-stat-icon">#</div>
+      <div class="hs-stat-body"><div class="hs-stat-label">热度</div><div class="hs-stat-value">87</div><div class="hs-stat-delta hs-delta-up">趋势上升</div></div>
+    </div>
+    <div class="hs-stat hs-stat--data">
+      <div class="hs-stat-icon">∑</div>
+      <div class="hs-stat-body"><div class="hs-stat-label">数据</div><div class="hs-stat-value" id="hs-stat-data">0</div><div class="hs-stat-delta" id="hs-stat-data-delta">四平台热榜</div></div>
+    </div>
+    <div class="hs-stat hs-stat--ai">
+      <div class="hs-stat-icon">AI</div>
+      <div class="hs-stat-body"><div class="hs-stat-label">Agent</div><div class="hs-stat-value">ON</div><div class="hs-stat-delta">上下文注入</div></div>
+    </div>
+  </section>
+
+  <main class="hs-body">
+    <section class="hs-col hs-col-left">
+      ${createPlatformCard('hs-douyin-card', 'douyin', '抖音', '短视频热榜', 'hs-douyin-list', 'hs-douyin-update')}
+      ${createPlatformCard('hs-xhs-card', 'xhs', '小红书', '生活方式热榜', 'hs-xhs-list', 'hs-xhs-update')}
+    </section>
+
+    <section class="hs-col hs-col-center">
+      <div class="hs-earth-container">
+        <canvas id="hs-earth-canvas"></canvas>
+        <div class="hs-earth-label">ATTENTION GLOBE</div>
+        <div class="hs-earth-hint">拖拽旋转 · 滚轮缩放</div>
+      </div>
+      <div class="hs-center-aux">
+        <div class="hs-aux-box">
+          <div class="hs-aux-title">区域关注 <span class="hs-aux-sub">REGION</span></div>
+          <div class="hs-region-list">
+            ${createRegionRow('华东', 72)}
+            ${createRegionRow('华北', 58)}
+            ${createRegionRow('华南', 44)}
+            ${createRegionRow('西南', 31)}
+          </div>
+        </div>
+        <div class="hs-aux-box">
+          <div class="hs-aux-title">舆情情绪 <span class="hs-aux-sub">SENTIMENT</span></div>
+          <div class="hs-sentiment">
+            <div class="hs-sentiment-ring">
+              <svg class="hs-ring-svg" viewBox="0 0 80 80" aria-hidden="true">
+                <circle cx="40" cy="40" r="32" fill="none" stroke="rgba(255,255,255,.10)" stroke-width="7" />
+                <circle cx="40" cy="40" r="32" fill="none" stroke="var(--cool)" stroke-width="7" stroke-linecap="round" stroke-dasharray="142 201" transform="rotate(-90 40 40)" />
+              </svg>
+              <div class="hs-ring-label"><div class="hs-ring-num">71</div><div class="hs-ring-text">neutral+</div></div>
+            </div>
+            <div class="hs-sentiment-delta">+4.8 / 24h</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="hs-col hs-col-right">
+      ${createPlatformCard('hs-wechat-card', 'wechat', '微信热点', '公众号热议', 'hs-wechat-list', 'hs-wechat-update')}
+      ${createPlatformCard('hs-weibo-card', 'weibo', '微博', '实时热搜', 'hs-weibo-list', 'hs-weibo-update')}
+    </section>
+  </main>
+
+  <section class="hs-feed-bar">
+    <div class="hs-feed-label">
+      <span class="hs-feed-live-dot">●</span>
+      <span>EVENTS</span>
+      <span class="hs-feed-subtitle">实时事件流</span>
+      <span class="hs-feed-desc">自动轮播重点事件</span>
+    </div>
+    <div class="hs-feed-viewport" id="hs-feed-viewport"><div class="hs-feed-track" id="hs-feed-track"></div></div>
+    <div class="hs-feed-controls">
+      <button class="hs-feed-nav" id="hs-feed-prev" type="button" title="上一条">‹</button>
+      <div class="hs-feed-auto-label">AUTO</div>
+      <button class="hs-feed-nav" id="hs-feed-next" type="button" title="下一条">›</button>
+    </div>
+  </section>
+
+  <footer class="hs-ticker-bar"><div class="hs-ticker-inner" id="hs-ticker-inner"></div></footer>
+</div>`;
+}
+
+function createPlatformCard(id, dot, name, badge, listId, updateId) {
+  return `
+    <article class="hs-list-card" id="${id}">
+      <div class="hs-card-header">
+        <span class="hs-platform-dot hs-dot-${dot}"></span>
+        <span class="hs-platform-name">${name}</span>
+        <span class="hs-card-badge">${badge}</span>
+        <span class="hs-card-update" id="${updateId}">加载中</span>
+      </div>
+      <ol class="hs-list" id="${listId}"></ol>
+    </article>`;
+}
+
+function createRegionRow(name, pct) {
+  return `<div class="hs-region-row"><span class="hs-region-name">${name}</span><span class="hs-bar-track"><span class="hs-bar-fill" style="width:${pct}%"></span></span><span class="hs-region-pct">${pct}%</span></div>`;
+}
+
+const SEED_GRAPH_NODES = [
+  ['system_architecture', '系统核心架构', 50, 15, 1.10, 'core'],
+  ['tick', 'TICK', 31, 25, .82, 'system'],
+  ['recognizer', '识别器', 50, 29, .82, 'system'],
+  ['injector', '注入器', 69, 25, .82, 'system'],
+  ['tools_system', '工具系统', 50, 49, 1.02, 'core'],
+  ['tool_send_message', 'send_message', 24, 46, .66, 'tool'],
+  ['tool_fetch_url', 'fetch_url', 36, 58, .66, 'tool'],
+  ['tool_write_read_file', 'file IO', 50, 62, .66, 'tool'],
+  ['tool_exec_command', 'exec', 64, 58, .66, 'tool'],
+  ['tool_search_memory', 'search_memory', 76, 46, .66, 'tool'],
+  ['tool_list_dir', 'list_dir', 20, 61, .55, 'tool'],
+  ['tool_delete_file', 'delete_file', 30, 70, .55, 'tool'],
+  ['tool_make_dir', 'make_dir', 42, 74, .55, 'tool'],
+  ['tool_kill_process', 'kill_process', 58, 74, .55, 'tool'],
+  ['tool_list_processes', 'list_processes', 70, 70, .55, 'tool'],
+  ['tool_speak', 'speak', 80, 61, .55, 'tool'],
+  ['tool_web_search', 'web_search', 85, 53, .58, 'tool'],
+  ['tool_browser_read', 'browser_read', 88, 68, .52, 'tool'],
+  ['tool_upsert_memory', 'upsert_memory', 14, 52, .55, 'tool'],
+  ['behavior_rules', '行为规范', 18, 17, .84, 'rule'],
+  ['rule_no_repeat', '不重复', 13, 30, .58, 'rule'],
+  ['rule_idle_ok', '安静等待', 24, 33, .58, 'rule'],
+  ['my_definition', '自我定义', 82, 16, .72, 'identity'],
+  ['ui_skills', 'ACUI', 22, 84, .80, 'skill'],
+  ['skill_weather_card', 'WeatherCard', 35, 88, .58, 'skill'],
+  ['task_system', '任务系统', 63, 88, .74, 'task'],
+  ['tool_marketplace', 'install_tool', 80, 84, .66, 'tool'],
+];
+
+const SEED_GRAPH_LINKS = [
+  ['system_architecture', 'tick'], ['system_architecture', 'recognizer'], ['system_architecture', 'injector'],
+  ['tick', 'rule_no_repeat'], ['tick', 'tool_send_message'], ['recognizer', 'injector'], ['injector', 'tool_search_memory'],
+  ['tools_system', 'tool_send_message'], ['tools_system', 'tool_fetch_url'], ['tools_system', 'tool_write_read_file'], ['tools_system', 'tool_exec_command'],
+  ['tools_system', 'tool_list_dir'], ['tools_system', 'tool_delete_file'], ['tools_system', 'tool_make_dir'], ['tools_system', 'tool_kill_process'],
+  ['tools_system', 'tool_list_processes'], ['tools_system', 'tool_search_memory'], ['tools_system', 'tool_speak'], ['tools_system', 'tool_web_search'],
+  ['tool_web_search', 'tool_fetch_url'], ['tool_browser_read', 'tool_fetch_url'], ['tool_upsert_memory', 'recognizer'],
+  ['behavior_rules', 'rule_no_repeat'], ['behavior_rules', 'rule_idle_ok'], ['rule_no_repeat', 'rule_idle_ok'],
+  ['my_definition', 'system_architecture'], ['ui_skills', 'skill_weather_card'], ['skill_weather_card', 'tool_fetch_url'],
+  ['task_system', 'tick'], ['task_system', 'behavior_rules'], ['tool_marketplace', 'tools_system'],
+];
+
+const SEED_GRAPH_DETAILS = {
+  system_architecture: 'TICK、识别器、注入器构成系统核心循环，让 Agent 能感知、积累、调用。',
+  tick: '时间心跳驱动无消息时的自发行动，有消息时约束第一步必须回复。',
+  recognizer: '每次经历结束后自动识别值得保留的内容并写入记忆。',
+  injector: '处理开始前让相关记忆被动浮现，进入当前上下文。',
+  tools_system: '内置工具让 Agent 与消息、网页、文件、命令、记忆、语音等外部系统交互。',
+  tool_send_message: '向已知目标发送消息，是收到外部消息后的第一优先工具。',
+  tool_fetch_url: '获取网页内容并带缓存，用于天气、百科、新闻等外部信息。',
+  tool_write_read_file: '在 sandbox 内读写任务产物，不用于记录想法或感受。',
+  tool_exec_command: '在 sandbox 内执行命令，支持前台和后台进程。',
+  tool_search_memory: '查询记忆库，辅助主动检索相关记忆。',
+  behavior_rules: '约束 Agent 行为边界，保证不重复、有节奏地自主行动。',
+  rule_no_repeat: 'TICK 中避免重复上一轮已完成的行动。',
+  rule_idle_ok: '无必要行动时允许安静等待，避免空转。',
+  my_definition: 'Agent 对自我结构、能力和边界的定义。',
+  ui_skills: 'ACUI 技能让 Agent 能通过 UI 卡片展示结构化信息。',
+  skill_weather_card: '天气卡片是 ACUI 技能的典型示例。',
+  task_system: '任务系统把长期目标拆成可执行、可追踪的步骤。',
+  tool_marketplace: '工具市场用于发现、安装和扩展新工具。',
+};
+
+function createSeedGraphMarkup() {
+  const nodeMap = new Map(SEED_GRAPH_NODES.map(([id, label, x, y, scale, group]) => [id, { id, label, x, y, scale, group }]));
+  const getRelated = (id) => SEED_GRAPH_LINKS
+    .filter(([source, target]) => source === id || target === id)
+    .map(([source, target]) => source === id ? target : source);
+  const lines = SEED_GRAPH_LINKS.map(([source, target]) => {
+    const a = nodeMap.get(source);
+    const b = nodeMap.get(target);
+    if (!a || !b) return '';
+    const soft = source !== 'system_architecture' && source !== 'tools_system' && source !== 'behavior_rules' && source !== 'ui_skills';
+    return `<line data-source="${escHtml(source)}" data-target="${escHtml(target)}" x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"${soft ? ' class="wiki-graph-line-soft"' : ''} />`;
+  }).join('');
+  const nodes = SEED_GRAPH_NODES.map(([id, label, x, y, scale, group]) => {
+    const related = getRelated(id);
+    return `<button class="wiki-tag wiki-node wiki-node-${group}" type="button" data-seed-id="${escHtml(id)}" data-seed-label="${escHtml(label)}" data-seed-group="${escHtml(group)}" data-seed-related="${escHtml(related.join(','))}" style="--x:${x}%;--y:${y}%;--s:${scale}" title="${escHtml(id)}">${escHtml(label)}</button>`;
+  }).join('');
+  return `
+    <svg class="wiki-graph-lines wiki-seed-graph-lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">${lines}</svg>
+    <div id="wiki-tag-cloud" class="wiki-tag-cloud wiki-graph-nodes wiki-seed-graph-nodes">${nodes}</div>
+    <div class="wiki-graph-stats"><span>${SEED_GRAPH_NODES.length} seed nodes</span><span>${SEED_GRAPH_LINKS.length} links</span><span>点击节点查看演进关系</span></div>`;
+}
+
+function createSeedDetailMarkup() {
+  return `
+    <div class="wiki-seed-detail" id="wiki-seed-detail" aria-live="polite">
+      <div class="wiki-seed-detail-kicker">Seed Memory Focus</div>
+      <div class="wiki-seed-detail-title">点击任一节点</div>
+      <div class="wiki-seed-detail-body">查看它如何从种子记忆连接到工具、规则、技能和任务系统。</div>
+    </div>`;
+}
+
+function createWikiPanel() {
+  return `
+<div class="wiki-panel" id="wiki-panel">
+  <div class="hs-header">
+    <div class="hs-brand">
+      <span class="hs-brand-name">知识库 v1.0</span>
+      <span class="hs-brand-dot">●</span>
+      <span class="hs-brand-status">Obsidian Vault</span>
+    </div>
+    <div class="hs-title-block">
+      <div class="hs-title-en">Personal Knowledge Base</div>
+      <div class="hs-title-zh">个人知识管理系统</div>
+    </div>
+    <div class="hs-header-right">
+      <div class="hs-header-meta">
+        <div class="hs-header-tag"><span class="hs-tag-icon">◈</span>本地存储<br><span class="hs-tag-status">/Users/merry/wiki</span></div>
+        <div class="hs-header-tag"><span class="hs-tag-icon">≡</span>文件总数<br><span class="hs-tag-status" id="wiki-total-count">--</span></div>
+        <div class="hs-header-tag"><span class="hs-tag-icon">⬡</span>索引状态<br><span class="hs-tag-status">就绪</span></div>
+      </div>
+      <div class="hs-clock-block">
+        <div class="hs-clock" id="wiki-clock">--:--:--</div>
+        <div class="hs-live-dot">● 在线</div>
+      </div>
+      <button class="hs-exit-btn" id="wiki-exit-btn" type="button" title="关闭知识库面板">×</button>
     </div>
   </div>
 
-  <!-- ── 统计条 ── -->
   <div class="hs-stats-bar">
-    <div class="hs-stat hs-stat--warn">
-      <div class="hs-stat-icon">⚠</div>
-      <div class="hs-stat-body">
-        <div class="hs-stat-label">全球预警事件</div>
-        <div class="hs-stat-value" id="hs-stat-alert">7</div>
-        <div class="hs-stat-delta hs-delta-up" id="hs-stat-alert-delta">较前15分钟 ↑2</div>
-      </div>
-    </div>
     <div class="hs-stat hs-stat--hot">
-      <div class="hs-stat-icon">🔥</div>
+      <div class="hs-stat-icon">◈</div>
       <div class="hs-stat-body">
-        <div class="hs-stat-label">高关注度事件</div>
-        <div class="hs-stat-value" id="hs-stat-hot">23</div>
-        <div class="hs-stat-delta hs-delta-up" id="hs-stat-hot-delta">较前15分钟 ↑6</div>
+        <div class="hs-stat-label">核心概念</div>
+        <div class="hs-stat-value" id="wiki-stat-concepts">66</div>
+        <div class="hs-stat-delta" id="wiki-stat-concepts-delta">Agent / Memory / Skill</div>
       </div>
     </div>
     <div class="hs-stat hs-stat--data">
       <div class="hs-stat-icon">◈</div>
       <div class="hs-stat-body">
-        <div class="hs-stat-label">信息源总量</div>
-        <div class="hs-stat-value" id="hs-stat-data">2.37M</div>
-        <div class="hs-stat-delta" id="hs-stat-data-delta">实时数据流/分钟</div>
+        <div class="hs-stat-label">个人笔记</div>
+        <div class="hs-stat-value" id="wiki-stat-life">251</div>
+        <div class="hs-stat-delta" id="wiki-stat-life-delta">收集/阅读/学习/项目</div>
+      </div>
+    </div>
+    <div class="hs-stat hs-stat--warn">
+      <div class="hs-stat-icon">◈</div>
+      <div class="hs-stat-body">
+        <div class="hs-stat-label">分析报告</div>
+        <div class="hs-stat-value" id="wiki-stat-articles">18</div>
+        <div class="hs-stat-delta" id="wiki-stat-articles-delta">articles/ 研究文档</div>
       </div>
     </div>
     <div class="hs-stat hs-stat--ai">
-      <div class="hs-stat-icon">⬡</div>
+      <div class="hs-stat-icon">◈</div>
       <div class="hs-stat-body">
-        <div class="hs-stat-label">AI 分析置信度</div>
-        <div class="hs-stat-value" id="hs-stat-ai">87%</div>
-        <div class="hs-stat-delta" id="hs-stat-ai-delta">模型状态：稳定</div>
+        <div class="hs-stat-label">实体与对比</div>
+        <div class="hs-stat-value" id="wiki-stat-other">11</div>
+        <div class="hs-stat-delta" id="wiki-stat-other-delta">entities / comparisons</div>
       </div>
     </div>
   </div>
 
-  <!-- ── 主体：左柱 + 中柱（地球）+ 右柱 ── -->
   <div class="hs-body">
-
-    <!-- 左柱 -->
     <div class="hs-col hs-col-left">
-
-      <!-- 抖音热榜 -->
-      <div class="hs-list-card" id="hs-douyin-card">
+      <div class="hs-list-card" id="wiki-concepts-card">
         <div class="hs-card-header">
           <span class="hs-platform-dot hs-dot-douyin"></span>
-          <span class="hs-platform-name">抖音</span>
-          <span class="hs-card-badge">热榜</span>
-          <span class="hs-card-update" id="hs-douyin-update">刚刚更新</span>
+          <span class="hs-platform-name">核心概念</span>
+          <span class="hs-card-badge">concepts/</span>
+          <span class="hs-card-update" id="wiki-concepts-update">66篇</span>
         </div>
-        <ul class="hs-list" id="hs-douyin-list">
-          <!-- JS 动态填充 -->
+        <ul class="hs-list" id="wiki-concepts-list">
+          <li class="hs-list-item hs-list-item--stub">Agent 执行循环</li>
+          <li class="hs-list-item hs-list-item--stub">Skill 双触发机制</li>
+          <li class="hs-list-item hs-list-item--stub">五层记忆系统</li>
+          <li class="hs-list-item hs-list-item--stub">MCP 协议</li>
         </ul>
       </div>
 
-      <!-- 小红书热榜 -->
-      <div class="hs-list-card" id="hs-xhs-card">
+      <div class="hs-list-card" id="wiki-life-card">
         <div class="hs-card-header">
           <span class="hs-platform-dot hs-dot-xhs"></span>
-          <span class="hs-platform-name">小红书</span>
-          <span class="hs-card-badge">热榜</span>
-          <span class="hs-card-update" id="hs-xhs-update">刚刚更新</span>
+          <span class="hs-platform-name">个人笔记</span>
+          <span class="hs-card-badge">life/</span>
+          <span class="hs-card-update" id="wiki-life-update">251条</span>
         </div>
-        <ul class="hs-list" id="hs-xhs-list">
-          <!-- JS 动态填充 -->
+        <ul class="hs-list" id="wiki-life-list">
+          <li class="hs-list-item hs-list-item--stub">学习笔记</li>
+          <li class="hs-list-item hs-list-item--stub">阅读摘录</li>
+          <li class="hs-list-item hs-list-item--stub">项目记录</li>
+          <li class="hs-list-item hs-list-item--stub">灵感收集</li>
         </ul>
       </div>
-
     </div>
 
-    <!-- 中柱：3D 地球 + 辅助面板 -->
     <div class="hs-col hs-col-center">
-
-      <!-- 地球容器 -->
-      <div class="hs-earth-container" id="hs-earth-container">
-        <div class="hs-earth-label">全球热力图</div>
-        <canvas id="hs-earth-canvas"></canvas>
-        <div class="hs-earth-hint">拖拽旋转 · 滚轮缩放</div>
+      <div class="hs-earth-container wiki-graph-container" id="wiki-graph-container">
+        <div class="hs-earth-label">种子记忆图谱</div>
+        ${createSeedGraphMarkup()}
+        <div class="hs-earth-hint">来自 scripts/seed-memories.js · 节点 = 种子记忆 · 连线 = links / parent</div>
       </div>
+      ${createSeedDetailMarkup()}
 
-      <!-- 辅助：区域关注度 + 情绪指数 -->
       <div class="hs-center-aux">
-
         <div class="hs-aux-box">
-          <div class="hs-aux-title">区域关注度 <span class="hs-aux-sub">实时排名</span></div>
-          <div class="hs-region-list" id="hs-region-list">
-            <div class="hs-region-row"><span class="hs-region-name">亚太地区</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:78%"></div></div><span class="hs-region-pct">78%</span></div>
-            <div class="hs-region-row"><span class="hs-region-name">北美地区</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:62%"></div></div><span class="hs-region-pct">62%</span></div>
-            <div class="hs-region-row"><span class="hs-region-name">欧洲地区</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:48%"></div></div><span class="hs-region-pct">48%</span></div>
-            <div class="hs-region-row"><span class="hs-region-name">中东地区</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:33%"></div></div><span class="hs-region-pct">33%</span></div>
-            <div class="hs-region-row"><span class="hs-region-name">南美地区</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:27%"></div></div><span class="hs-region-pct">27%</span></div>
-            <div class="hs-region-row"><span class="hs-region-name">非洲地区</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:19%"></div></div><span class="hs-region-pct">19%</span></div>
+          <div class="hs-aux-title">内容分布 <span class="hs-aux-sub">各目录文件数</span></div>
+          <div class="hs-region-list" id="wiki-dist-list">
+            <div class="hs-region-row"><span class="hs-region-name">concepts/</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:60%"></div></div><span class="hs-region-pct">66</span></div>
+            <div class="hs-region-row"><span class="hs-region-name">life/</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:85%"></div></div><span class="hs-region-pct">251</span></div>
+            <div class="hs-region-row"><span class="hs-region-name">articles/</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:15%"></div></div><span class="hs-region-pct">18</span></div>
+            <div class="hs-region-row"><span class="hs-region-name">entities/</span><div class="hs-bar-track"><div class="hs-bar-fill" style="width:5%"></div></div><span class="hs-region-pct">5</span></div>
           </div>
         </div>
 
         <div class="hs-aux-box">
-          <div class="hs-aux-title">情绪指数 <span class="hs-aux-sub">实时指标</span></div>
-          <div class="hs-sentiment">
+          <div class="hs-aux-title">最近更新 <span class="hs-aux-sub">当日活跃文件</span></div>
+          <div class="hs-sentiment" id="wiki-recent-box">
             <div class="hs-sentiment-ring">
               <svg viewBox="0 0 80 80" class="hs-ring-svg" aria-hidden="true">
                 <circle cx="40" cy="40" r="28" fill="none" stroke="var(--line-strong)" stroke-width="5"/>
-                <circle cx="40" cy="40" r="28" fill="none" stroke="var(--cool)" stroke-width="5"
-                  stroke-dasharray="175.9" stroke-dashoffset="70"
-                  stroke-linecap="round" transform="rotate(-90 40 40)"
-                  id="hs-sentiment-arc"/>
+                <circle cx="40" cy="40" r="28" fill="none" stroke="var(--cool)" stroke-width="5" stroke-dasharray="175.9" stroke-dashoffset="120" stroke-linecap="round" transform="rotate(-90 40 40)"/>
               </svg>
               <div class="hs-ring-label">
-                <div class="hs-ring-num" id="hs-sentiment-num">64</div>
-                <div class="hs-ring-text" id="hs-sentiment-text">中性偏热</div>
+                <div class="hs-ring-num" id="wiki-recent-num">--</div>
+                <div class="hs-ring-text">今日更新</div>
               </div>
             </div>
-            <div class="hs-sentiment-delta hs-delta-up" id="hs-sentiment-delta">↑ 3.12%</div>
+            <div class="hs-sentiment-delta" id="wiki-recent-delta">扫描中...</div>
           </div>
         </div>
-
       </div>
     </div>
 
-    <!-- 右柱 -->
     <div class="hs-col hs-col-right">
-
-      <!-- 微信热点榜 -->
-      <div class="hs-list-card" id="hs-wechat-card">
+      <div class="hs-list-card" id="wiki-articles-card">
         <div class="hs-card-header">
           <span class="hs-platform-dot hs-dot-wechat"></span>
-          <span class="hs-platform-name">微信热点</span>
-          <span class="hs-card-badge">热点榜</span>
-          <span class="hs-card-update" id="hs-wechat-update">刚刚更新</span>
+          <span class="hs-platform-name">最近更新</span>
+          <span class="hs-card-badge">latest/</span>
+          <span class="hs-card-update" id="wiki-articles-update">扫描中</span>
         </div>
-        <ul class="hs-list" id="hs-wechat-list">
-          <!-- JS 动态填充 -->
+        <ul class="hs-list" id="wiki-articles-list">
+          <li class="hs-list-item hs-list-item--stub">agent-base-architecture-report.md</li>
+          <li class="hs-list-item hs-list-item--stub">hermes-comparison.md</li>
+          <li class="hs-list-item hs-list-item--stub">skill-evolution.md</li>
         </ul>
       </div>
 
-      <!-- 微博热榜 -->
-      <div class="hs-list-card" id="hs-weibo-card">
+      <div class="hs-list-card" id="wiki-other-card">
         <div class="hs-card-header">
           <span class="hs-platform-dot hs-dot-weibo"></span>
-          <span class="hs-platform-name">微博</span>
-          <span class="hs-card-badge">热搜榜</span>
-          <span class="hs-card-update" id="hs-weibo-update">刚刚更新</span>
+          <span class="hs-platform-name">实体与对比</span>
+          <span class="hs-card-badge">entities/ + comparisons/</span>
+          <span class="hs-card-update" id="wiki-other-update">12个</span>
         </div>
-        <ul class="hs-list" id="hs-weibo-list">
-          <!-- JS 动态填充 -->
+        <ul class="hs-list" id="wiki-other-list">
+          <li class="hs-list-item hs-list-item--stub">hermes-agent.md</li>
+          <li class="hs-list-item hs-list-item--stub">openclaw.md</li>
+          <li class="hs-list-item hs-list-item--stub">bailongma-vs-hermes.md</li>
         </ul>
       </div>
-
     </div>
   </div>
 
-  <!-- ── 实时事件流（横向卡片轮播） ── -->
   <div class="hs-feed-bar">
     <div class="hs-feed-label">
       <span class="hs-feed-live-dot">●</span>
-      <span>实时</span>
-      <span class="hs-feed-subtitle">实时事件流</span>
-      <span class="hs-feed-desc">24/7 全球热点持续追踪</span>
+      <span>知识</span>
+      <span class="hs-feed-subtitle">Recent Updates</span>
+      <span class="hs-feed-desc">/Users/merry/wiki · Obsidian Vault</span>
     </div>
-    <div class="hs-feed-viewport" id="hs-feed-viewport">
-      <div class="hs-feed-track" id="hs-feed-track">
-        <!-- JS 动态填充 -->
+    <div class="hs-feed-viewport" id="wiki-feed-viewport">
+      <div class="hs-feed-track" id="wiki-feed-track">
+        <span class="hs-feed-item">concepts/agent-base-architecture.md</span>
+        <span class="hs-feed-item">concepts/skill-double-trigger.md</span>
+        <span class="hs-feed-item">life/学习笔记/</span>
+        <span class="hs-feed-item">articles/agent-base-architecture-report.md</span>
+        <span class="hs-feed-item">entities/hermes-agent.md</span>
       </div>
     </div>
     <div class="hs-feed-controls">
-      <span class="hs-feed-auto-label" id="hs-feed-auto">自动滚动中</span>
-      <button class="hs-feed-nav" id="hs-feed-prev" type="button" aria-label="上一条">‹</button>
-      <button class="hs-feed-nav" id="hs-feed-next" type="button" aria-label="下一条">›</button>
+      <span class="hs-feed-auto-label">知识库索引</span>
+      <button class="hs-feed-nav" id="wiki-search-btn" type="button" title="搜索">⌕</button>
     </div>
   </div>
 
-  <!-- ── 底部跑马灯 ── -->
   <div class="hs-ticker-bar">
-    <div class="hs-ticker-inner" id="hs-ticker-inner">
-      <!-- JS 动态填充（内容翻倍实现无缝滚动） -->
+    <div class="hs-ticker-inner" id="wiki-ticker-inner">
+      Hermes · OpenClaw · nanobot · opencode · Agent架构 · Memory体系 · Skill机制 · 多智能体 · RL训练 · MCP/A2A/AGUI
     </div>
   </div>
+</div>`;
+}
 
-</div>
-`;
+// ── 导出（供热键调用） ─────────────────────────────────────────
+window.openHotspotPanel = openHotspotPanel;
+window.closeHotspotPanel = closeHotspotPanel;
+window.toggleHotspotPanel = toggleHotspotPanel;
+window.openWikiPanel = openWikiPanel;
+window.closeWikiPanel = closeWikiPanel;
+window.toggleWikiPanel = toggleWikiPanel;
+window.closeAllPanels = closeAllPanels;
+window.loadHotspotData = loadHotspotData;
+window.doWikiSearch = doWikiSearch;

--- a/src/ui/brain-ui/hotspot.js
+++ b/src/ui/brain-ui/hotspot.js
@@ -374,6 +374,8 @@ export function setHotspotMode(visible, { source = 'brain-ui' } = {}) {
     stopHotspotRefresh();
     restoreVoicePanel();
   } else {
+    window.closeWikiPanel?.();
+
     // 关闭其他媒体模式（互斥）
     if (document.body.classList.contains('video-mode'))
       document.body.classList.remove('video-mode');

--- a/src/ui/brain-ui/styles.css
+++ b/src/ui/brain-ui/styles.css
@@ -2979,6 +2979,390 @@ body.video-mode   > #voice-panel #voice-canvas {
   padding: 0 6px;
 }
 
+body.wiki-panel-mode #panel-l1 { transform: translateX(calc(-100% - 20px)); }
+body.wiki-panel-mode #panel-l2 { transform: translateX(calc(100% + 20px)); }
+body.wiki-panel-mode .console  { left: calc(66vw + 8px); right: 16px; }
+body.wiki-panel-mode #graph    { transform: none; }
+body.wiki-panel-mode .panel-tab { opacity: 0; pointer-events: none; transition: opacity 0.3s ease; }
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Wiki 面板  WIKI PANEL
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.wiki-panel {
+  position: fixed;
+  left: 16px;
+  top: 16px;
+  bottom: 16px;
+  width: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--bg-deep) 94%, #001018);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    width 0.45s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.35s ease,
+    border-color 0.35s ease;
+}
+
+.wiki-panel.active {
+  width: calc(66vw - 32px);
+  opacity: 1;
+  pointer-events: auto;
+  border-color: var(--line-strong);
+}
+
+.wiki-panel .hs-body {
+  flex: 1 1 0;
+}
+
+.wiki-panel .hs-col-center {
+  gap: 10px;
+  padding: 10px;
+}
+
+.wiki-panel .wiki-graph-container {
+  flex: 1 1 58%;
+  min-height: 320px;
+  border: 1px solid rgba(143,182,216,.16);
+  border-radius: 14px;
+}
+
+.wiki-panel .hs-center-aux {
+  flex: 0 0 118px;
+  border: 1px solid rgba(143,182,216,.12);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.wiki-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  padding: 24px;
+  width: 100%;
+  height: 100%;
+}
+
+.wiki-tag {
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: rgba(255,255,255,.045);
+  color: var(--ink2);
+  padding: 6px 12px;
+  cursor: default;
+  transition: color 150ms ease, border-color 150ms ease, background 150ms ease;
+}
+
+.wiki-tag:hover {
+  color: var(--ink);
+  border-color: var(--cool);
+  background: rgba(143,182,216,.10);
+}
+
+.wiki-graph-container {
+  background:
+    radial-gradient(circle at 50% 48%, rgba(143,182,216,.16), transparent 34%),
+    linear-gradient(180deg, #07111d 0%, #050a12 100%);
+}
+
+.wiki-graph-container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: .22;
+  background-image:
+    linear-gradient(rgba(143,182,216,.10) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(143,182,216,.10) 1px, transparent 1px);
+  background-size: 34px 34px;
+  mask-image: radial-gradient(circle at center, black 30%, transparent 82%);
+}
+
+.wiki-graph-lines {
+  position: absolute;
+  inset: 34px 18px 26px;
+  width: calc(100% - 36px);
+  height: calc(100% - 60px);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.wiki-graph-lines line {
+  stroke: rgba(143,182,216,.26);
+  stroke-width: .72;
+  stroke-linecap: round;
+  stroke-dasharray: 2 7;
+  vector-effect: non-scaling-stroke;
+}
+
+.wiki-graph-lines .wiki-graph-line-soft {
+  stroke: rgba(143,182,216,.14);
+  stroke-width: .56;
+}
+
+.wiki-graph-nodes {
+  position: absolute;
+  inset: 40px 20px 34px;
+  display: block;
+  padding: 0;
+  width: auto;
+  height: auto;
+  z-index: 2;
+}
+
+.wiki-node {
+  position: absolute;
+  left: var(--x);
+  top: var(--y);
+  transform: translate(-50%, -50%) scale(var(--s, 1));
+  min-width: 72px;
+  text-align: center;
+  border-color: rgba(143,182,216,.42);
+  background:
+    linear-gradient(145deg, rgba(143,182,216,.16), rgba(255,255,255,.035)),
+    rgba(9,18,28,.92);
+  color: var(--ink);
+  box-shadow: 0 0 22px rgba(143,182,216,.07), inset 0 1px 0 rgba(255,255,255,.06);
+  cursor: pointer;
+  font: inherit;
+}
+
+.wiki-node:focus-visible {
+  outline: 2px solid var(--cool);
+  outline-offset: 3px;
+}
+
+.wiki-node-core {
+  min-width: 92px;
+  border-color: var(--cool);
+  color: #eaf6ff;
+  background:
+    radial-gradient(circle at top, rgba(143,182,216,.34), transparent 62%),
+    rgba(16,32,46,.96);
+  box-shadow: 0 0 34px rgba(143,182,216,.24), inset 0 1px 0 rgba(255,255,255,.10);
+}
+
+.wiki-node-active {
+  z-index: 5;
+  border-color: #fff;
+  color: #fff;
+  background:
+    radial-gradient(circle at top, rgba(143,182,216,.48), transparent 64%),
+    rgba(20,42,60,.98);
+  box-shadow: 0 0 38px rgba(143,182,216,.46), 0 0 0 1px rgba(255,255,255,.18), inset 0 1px 0 rgba(255,255,255,.16);
+}
+
+.wiki-node-related {
+  z-index: 4;
+  border-color: rgba(143,182,216,.84);
+  color: var(--ink);
+  box-shadow: 0 0 24px rgba(143,182,216,.24), inset 0 1px 0 rgba(255,255,255,.10);
+}
+
+.wiki-node-dimmed {
+  opacity: .34;
+}
+
+.wiki-graph-lines line.wiki-graph-line-active {
+  stroke: rgba(205,231,255,.74);
+  stroke-width: 1.15;
+  stroke-dasharray: 4 4;
+}
+
+.wiki-graph-lines line.wiki-graph-line-dimmed {
+  opacity: .12;
+}
+
+.wiki-node-minor {
+  color: var(--ink2);
+  border-color: rgba(143,182,216,.24);
+  background: rgba(9,18,28,.76);
+}
+
+.wiki-graph-stats {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 28px;
+  z-index: 3;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.wiki-graph-stats span {
+  border: 1px solid rgba(143,182,216,.20);
+  border-radius: 999px;
+  background: rgba(0,0,0,.18);
+  color: var(--dim);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+  padding: 3px 8px;
+}
+
+.wiki-seed-detail {
+  flex: 0 0 104px;
+  max-height: 104px;
+  min-height: 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(143,182,216,.22);
+  border-radius: 12px;
+  background: rgba(5,10,18,.78);
+  box-shadow: 0 14px 38px rgba(0,0,0,.16), inset 0 1px 0 rgba(255,255,255,.06);
+  overflow: hidden;
+}
+
+.wiki-seed-detail-kicker {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--cool);
+  margin-bottom: 4px;
+}
+
+.wiki-seed-detail-title {
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 5px;
+}
+
+.wiki-seed-detail-body {
+  color: var(--ink2);
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wiki-seed-detail-links {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  margin-top: 7px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 2px;
+}
+
+.wiki-seed-detail-links span {
+  border: 1px solid rgba(143,182,216,.18);
+  border-radius: 999px;
+  color: var(--dim);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+  padding: 2px 7px;
+  background: rgba(143,182,216,.06);
+}
+
+.hs-list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  color: var(--ink2);
+  font-size: 11px;
+  line-height: 1.45;
+  border-left: 2px solid transparent;
+}
+
+.hs-list-item:hover {
+  color: var(--ink);
+  background: var(--line);
+  border-left-color: var(--cool);
+}
+
+.hs-list-item--wiki-update {
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.wiki-list-file {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wiki-list-time {
+  flex: 0 0 auto;
+  color: var(--dim);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+.hs-list-item--stub {
+  color: var(--ink2);
+}
+
+.wiki-panel .hs-feed-bar {
+  height: 104px;
+}
+
+.wiki-panel .hs-feed-track {
+  align-items: stretch;
+}
+
+.wiki-panel .hs-feed-item {
+  flex: 0 0 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  height: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  background:
+    linear-gradient(145deg, rgba(143,182,216,.08), transparent 42%),
+    var(--bg1);
+  color: var(--ink);
+  font-size: 10.5px;
+  line-height: 1.35;
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+}
+
+.wiki-panel .hs-feed-item:hover {
+  border-color: var(--cool);
+  background: color-mix(in srgb, var(--bg1) 82%, var(--cool) 8%);
+}
+
+.wiki-update-path,
+.wiki-update-time {
+  display: block;
+}
+
+.wiki-update-path {
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.wiki-update-time {
+  margin-top: 4px;
+  color: var(--dim);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
    人物卡片模式  PERSON CARD MODE
    ───────────────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## 概要

本 PR 包含三类 Brain UI 改动：

1. **Wiki 知识库面板**（默认不挂载，`Control+Option+W` 动态打开）
2. **视频播放链路修复**（`V` 热键 + `media_mode` 双路径）
3. **回归测试 + 依赖 bump**

## Wiki 知识库

- 后端 `src/api.js`: 新增 `GET /wiki-stats` 路由，扫描 `$HOME/wiki`。
  返回：
  - 总文件数 / 今日更新 / 7 日更新
  - 目录分布（top 8）
  - 最近 12 个文件
- 前端 `src/ui/brain-ui/hotspot-panel.js`: 拆分为 Hotspot + Wiki 双面板，
  按需动态挂载。Wiki 节点可点击演进，详情卡片位于图谱下方。
- 知识库面板 4 个 stats 卡片 + 底部更新条 + 目录分布条 + 右侧最近更新
  全部接入 `/wiki-stats`。
- 详情卡片从图谱中下移，避免遮挡图谱节点。
- 图谱连线改为细虚线（`.72` / `.56` 描边 + dash），激活态加粗高亮。
- 底部更新条高度从 146px 缩小到 104px。
- Hotspot 与 Wiki 互斥：开 Hotspot 自动关 Wiki，反之亦然。

## 视频播放

- `src/ui/brain-ui/app.js`: `showVideo()` 同时支持 `url` 和 `src`。
  之前 `media_mode` 工具支持 `src` 字段，但前端只读 `url`，会导致
  Agent 传 `src` 时面板空开。
- 保留 `V` 热键打开/折叠空视频面板的行为，方便手动进入视频模式。

## 测试

- `scripts/smoke-brain-ui.mjs`:
  - 新增 `/wiki-stats`、`/smoke-video.mp4`、`/media/history`、`/hotspot-state` mock
  - 新增 `V` 热键断言
  - 新增 `media_mode` 视频加载 + 折叠恢复 + 关闭清空 断言
  - 已有 Wiki 27 节点 / 31 连线 / 详情卡在图谱下方 断言
  - smoke 结果：所有断言通过

## 依赖

- `package.json`:
  - `better-sqlite3`: 12.8.0 → 12.10.0
  - `electron`: 33.2.0 → 33.4.11

## .gitignore

- 忽略 `.deepseek/` 目录。

## 不包含

- `config.json`（含真实 API key / bot token，本地保留）
- `wiki-panel.js`、`wiki-preview.html`（草稿）
- `docs/`、`AGENTS.md`、`build_native.sh`（本地/文档性文件）
- `.DS_Store`、`src/.DS_Store`、`node_modules_bin_npm`、`nul`

## 验证

```bash
npm run smoke:brain-ui   # PASS
node --check src/ui/brain-ui/app.js
node --check src/api.js
node --check src/ui/brain-ui/hotspot.js
node --check src/ui/brain-ui/hotspot-panel.js
node --check scripts/smoke-brain-ui.mjs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)