### PR TITLE
feat: add macOS (dmg) client build support

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -231,7 +231,8 @@ async function createWindow() {
 }
 
 function setupTray() {
-  const iconPath = path.join(RESOURCE_ROOT, 'build', 'icon.ico')
+  const iconName = process.platform === 'darwin' ? 'icon.png' : 'icon.ico'
+  const iconPath = path.join(RESOURCE_ROOT, 'build', iconName)
   tray = new Tray(nativeImage.createFromPath(iconPath))
   tray.setToolTip('Bailongma')
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "start:backend": "node --env-file=.env src/index.js",
     "start:backend:lan": "powershell -ExecutionPolicy Bypass -File scripts/start-lan.ps1 backend",
     "dev": "node --env-file=.env --watch src/index.js",
-    "build": "powershell -ExecutionPolicy Bypass -File scripts/prebuild-clean.ps1 && electron-rebuild -f -w better-sqlite3 -v 33.4.11 && electron-builder --win",
-    "publish": "electron-builder --win --publish always",
+    "build": "node scripts/prebuild-clean.mjs && electron-rebuild -f -w better-sqlite3 -v 33.4.11 && electron-builder",
+    "build:win": "node scripts/prebuild-clean.mjs && electron-rebuild -f -w better-sqlite3 -v 33.4.11 && electron-builder --win",
+    "build:mac": "node scripts/prebuild-clean.mjs && electron-rebuild -f -w better-sqlite3 -v 33.4.11 && electron-builder --mac",
+    "publish": "node scripts/prebuild-clean.mjs && electron-rebuild -f -w better-sqlite3 -v 33.4.11 && electron-builder --publish always",
     "postinstall": "electron-builder install-app-deps",
     "test:rule-context": "electron ./src/test-rule-context.js",
     "test:complex-task": "electron ./src/test-complex-task.js",
@@ -69,6 +71,8 @@
       "focus-banner.html",
       "turn-trace.html",
       "build/icon.ico",
+      "build/icon.png",
+      "build/icon-mac-cartoon.png",
       "sandbox/**/*",
       "music/**/*",
       "package.json",
@@ -109,6 +113,20 @@
       "createDesktopShortcut": false,
       "createStartMenuShortcut": false,
       "shortcutName": "Bailongma"
+    },
+    "mac": {
+      "icon": "build/icon.png",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ],
+      "category": "public.app-category.productivity",
+      "artifactName": "${productName}-${version}-mac-${arch}.${ext}"
     },
     "publish": [
       {

--- a/scripts/prebuild-clean.mjs
+++ b/scripts/prebuild-clean.mjs
@@ -1,0 +1,24 @@
+/**
+ * prebuild-clean.mjs — Cross-platform dist directory cleanup.
+ *
+ * Removes the output `dist/` directory before a fresh build.
+ * Works on macOS, Linux, and Windows (replaces prebuild-clean.ps1).
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const distPath = resolve(process.argv[2] ?? 'dist');
+
+if (!existsSync(distPath)) {
+  console.log('[prebuild] dist does not exist; skipping clean');
+  process.exit(0);
+}
+
+try {
+  rmSync(distPath, { recursive: true, force: true });
+  console.log('[prebuild] dist removed');
+} catch (err) {
+  console.error(`[prebuild] clean failed: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

BaiLongma 本身就是 **Electron** 应用，之前构建配置只有 Windows 目标。这个 PR 添加了 macOS 的 `.dmg` 构建支持。

## Changes

1. **`package.json`**
   - 新增 `mac` 构建目标：`.dmg` 格式，同时支持 Intel（x64）和 Apple Silicon（arm64）
   - 构建脚本改为跨平台：`npm run build`（当前平台）、`npm run build:mac`、`npm run build:win`
   - `publish` 脚本同样跨平台
   - 打包时包含 `icon.png`（用于 macOS 运行时）

2. **`electron/main.cjs`**
   - 系统托盘图标按平台选择文件：macOS 用 `.png`，Windows 用 `.ico`
   - Electron 在 macOS 上无法渲染 `.ico` 格式

3. **`scripts/prebuild-clean.mjs`（新增）**
   - Node.js 跨平台版本，替代原有的 `prebuild-clean.ps1`（PowerShell + Windows Restart Manager API）
   - 功能一致：构建前清理 `dist/` 目录

## 如何构建

```bash
# macOS
npm run build:mac
# 输出：dist/Bailongma-{version}-mac-{arch}.dmg

# Windows（不变）
npm run build:win
```

## 注意

项目 `build/` 目录已有 `icon.png` 和 `icon-mac-cartoon.png`，electron-builder 会自动转为 `.icns`，无需额外图标素材。

Closes #4