### PR TITLE
fix(brain-ui): restore hotspot earth after resource release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bailongma",
-  "version": "2.2.116",
+  "version": "2.2.117",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bailongma",
-      "version": "2.2.116",
+      "version": "2.2.117",
       "hasInstallScript": true,
       "dependencies": {
         "@huggingface/transformers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bailongma",
   "productName": "Bailongma",
-  "version": "2.2.116",
+  "version": "2.2.117",
   "description": "A continuously running digital consciousness framework",
   "type": "module",
   "main": "electron/main.cjs",
@@ -39,6 +39,7 @@
     "test:rule-context": "electron ./src/test-rule-context.js",
     "test:i18n": "node ./src/test-i18n.js",
     "test:brain-ui-tools": "node ./src/test-brain-ui-tool-descriptions.js",
+    "test:hotspot-earth": "node ./src/test-hotspot-earth-lifecycle.js",
     "test:information-subscriptions": "electron ./src/test-information-subscriptions.js",
     "test:device-information": "node ./src/test-device-information.js",
     "test:complex-task": "electron ./src/test-complex-task.js",

--- a/src/test-hotspot-earth-lifecycle.js
+++ b/src/test-hotspot-earth-lifecycle.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { HotspotEarth } from './ui/brain-ui/hotspot-earth.js';
+
+const calls = [];
+const parent = {};
+const replacementCanvas = {
+  id: 'hs-earth-canvas',
+  parentNode: parent,
+};
+let currentCanvas = null;
+
+const canvas = {
+  id: 'hs-earth-canvas',
+  parentNode: parent,
+  removeEventListener() {},
+  cloneNode(deep) {
+    calls.push('canvas.clone');
+    assert.equal(deep, false, 'the replacement must not inherit runtime children');
+    return replacementCanvas;
+  },
+  replaceWith(next) {
+    calls.push('canvas.replace');
+    assert.equal(next, replacementCanvas);
+    currentCanvas = next;
+    this.parentNode = null;
+  },
+};
+currentCanvas = canvas;
+
+const earth = new HotspotEarth(canvas);
+earth.scene = { traverse() {} };
+earth.renderer = {
+  renderLists: {
+    dispose() { calls.push('renderLists.dispose'); },
+  },
+  dispose() { calls.push('renderer.dispose'); },
+  forceContextLoss() { calls.push('renderer.forceContextLoss'); },
+};
+
+const freshCanvas = earth.dispose();
+
+assert.equal(freshCanvas, replacementCanvas, 'dispose returns the fresh canvas');
+assert.equal(currentCanvas, replacementCanvas, 'the lost-context canvas is replaced in the DOM');
+assert.equal(earth.canvas, null, 'the disposed instance releases its canvas reference');
+assert.deepEqual(calls, [
+  'renderLists.dispose',
+  'renderer.dispose',
+  'renderer.forceContextLoss',
+  'canvas.clone',
+  'canvas.replace',
+]);
+
+const reopenedEarth = new HotspotEarth(currentCanvas);
+assert.equal(reopenedEarth.canvas, replacementCanvas, 'reopening uses the fresh canvas');
+assert.equal(reopenedEarth.disposed, false, 'the replacement instance can initialize normally');
+
+assert.equal(earth.dispose(), null, 'repeated disposal is a no-op');
+assert.equal(calls.filter((call) => call === 'renderer.forceContextLoss').length, 1,
+  'the old WebGL context is released only once');
+
+console.log('Hotspot earth lifecycle tests passed');

--- a/src/ui/brain-ui/hotspot-earth.js
+++ b/src/ui/brain-ui/hotspot-earth.js
@@ -449,7 +449,7 @@ export class HotspotEarth {
   }
 
   dispose() {
-    if (this.disposed) return;
+    if (this.disposed) return null;
     this.disposed = true;
     if (this.animFrame) cancelAnimationFrame(this.animFrame);
     this.animFrame = null;
@@ -478,6 +478,17 @@ export class HotspotEarth {
     this.renderer?.dispose();
     // WebGLRenderer.dispose() 会清空 three 的缓存；强制丢失 context 可立即归还 GPU 资源。
     this.renderer?.forceContextLoss?.();
+
+    // WEBGL_lose_context 会让当前 canvas 继续绑定一个已丢失的 context。若下次打开热点
+    // 仍复用它，新的 WebGLRenderer 可能只能拿到这个失效 context，最终显示为空白。
+    // 原位换成无事件监听、无 WebGL context 的新 canvas，既保留立即回收 GPU 的策略，
+    // 又让下一次懒加载可以创建全新的 context。
+    let replacementCanvas = null;
+    if (c?.parentNode && typeof c.cloneNode === 'function' && typeof c.replaceWith === 'function') {
+      replacementCanvas = c.cloneNode(false);
+      c.replaceWith(replacementCanvas);
+    }
+    this.canvas = null;
     this.renderer = null;
     this.scene = null;
     this.camera = null;
@@ -487,5 +498,6 @@ export class HotspotEarth {
     this.atmo2 = null;
     this.stars = null;
     this.hotspots = null;
+    return replacementCanvas;
   }
 }


### PR DESCRIPTION
## Summary
- replace the lost-context hotspot canvas after WebGL resource disposal
- preserve the five-minute GPU resource reclamation policy
- bump the patch version to 2.2.117
- add a lifecycle regression test for dispose and reopen

## Validation
- npm run test:hotspot-earth
- 543 JavaScript files passed syntax checks
- related Brain UI, config, packaging, native dependency, and release tests passed
- macOS x64 and arm64 Developer ID signed builds passed artifact smoke tests (not notarized)