### PR TITLE
chore: remove leaked local config and test key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 # Logs
 logs
 *.log
@@ -157,3 +158,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# local runtime config (contains real API keys)
+config.json

--- a/config.json
+++ b/config.json
@@ -1,16 +1,1 @@
-{
-  "clawbot": {},
-  "tts": {
-    "ttsProvider": "doubao",
-    "ttsVoiceId": "zh_male_m191_uranus_bigtts",
-    "doubaoSpeechRate": 20,
-    "doubaoKey": "0f9a6c2b-8d91-4f2b-92b0-531c357b24da"
-  },
-  "embedding": {},
-  "schemaVersion": 4,
-  "contextWindow": {
-    "chatMessageLimit": 20,
-    "toolCallLimit": 5
-  },
-  "provider": "deepseek"
-}
+{}

--- a/src/test-key-auto-config.js
+++ b/src/test-key-auto-config.js
@@ -1,3 +1,4 @@
+
 // Key auto-config should not bind a fresh key to stale provider words from chat history.
 //
 // Run: node src/test-key-auto-config.js
@@ -57,7 +58,7 @@ function findTtsProvider(infos, provider) {
 }
 
 {
-  const infos = detectAllKeyInfos('配置火山语音识别 0f9a6c2b-8d91-4f2b-92b0-531c357b24da')
+  const infos = detectAllKeyInfos('配置火山语音识别 01234567-89ab-4cde-8f01-23456789abcd')
   const volc = findAsrProvider(infos, 'volcengine')
   assert(!!volc, 'explicit Volcengine ASR key is detected')
   assert(volc.configUpdates?.voiceProvider === 'volcengine', 'Volcengine ASR auto-config sets voice provider')
@@ -70,7 +71,7 @@ function findTtsProvider(infos, provider) {
 }
 
 {
-  const infos = detectAllKeyInfos('配置豆包 TTS 0f9a6c2b-8d91-4f2b-92b0-531c357b24da')
+  const infos = detectAllKeyInfos('配置豆包 TTS 01234567-89ab-4cde-8f01-23456789abcd')
   const doubao = findTtsProvider(infos, 'doubao')
   assert(!!doubao, 'explicit Doubao TTS key is detected')
   assert(doubao.configUpdates?.ttsVoiceId === DEFAULT_DOUBAO_VOICE_ID, 'Doubao TTS auto-config selects Yunzhou 2.0 by default')


### PR DESCRIPTION
Security cleanup: config.json contained real API keys (Volcano/Doubao TTS) and was pushed to this public repo. The keys have been revoked on the provider consoles.

- remove config.json from the repo (now gitignored)
- replace leaked Volcano key in key-detection test with placeholder UUID